### PR TITLE
Add policies to enable reading two Terraform states

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,23 @@ This project is used to manage IAM permissions for
 
 ## Pre-requisites ##
 
-- The user accounts for all users must have been created previously.  We
-recommend using the
-[`cisagov/cool-users-non-admin`](https://github.com/cisagov/cool-users-non-admin)
-repository to create users.
-- The User Services account and roles must have been created using [`cisagov/cool-accounts-userservices`](https://github.com/cisagov/cool-accounts-userservices).
+- [Terraform](https://www.terraform.io/) installed on your system.
+- An accessible AWS S3 bucket to store Terraform state
+  (specified in [backend.tf](backend.tf)).
+- An accessible AWS DynamoDB database to store the Terraform state lock
+  (specified in [backend.tf](backend.tf)).
+- Access to all of the Terraform remote states specified in
+  [remote_states.tf](remote_states.tf).
+- User accounts for all users must have been created previously.  We
+  recommend using the
+  [`cisagov/cool-users-non-admin`](https://github.com/cisagov/cool-users-non-admin)
+  repository to create users.
+- User Services account and roles must have been created using
+  [`cisagov/cool-accounts-userservices`](https://github.com/cisagov/cool-accounts-userservices).
+- Terraform in [`cisagov/cool-sharedservices-networking`](https://github.com/cisagov/cool-sharedservices-networking)
+  must have been applied.
+- Terraform in [`cisagov/cool-userservices-networking`](https://github.com/cisagov/cool-userservices-networking)
+  must have been applied.
 
 ## Usage ##
 

--- a/assume_read_sharedservices_networking_state_role.tf
+++ b/assume_read_sharedservices_networking_state_role.tf
@@ -1,0 +1,14 @@
+# Attach to the provisioners users group the IAM policy (created in
+# cisagov/cool-sharedservices-networking) that allows assumption of the role
+# in the Terraform account that allows read-only access to the
+# cool-sharedservices-networking Terraform state.
+resource "aws_iam_group_policy_attachment" "assume_read_sharedservices_networking_state_role" {
+  provider = aws.users
+
+  group = aws_iam_group.provisioner_users.name
+  # There is only one Users account, so both sharedservices_networking
+  # remote states (production and staging) point to the same
+  # "assume_read_terraform_state_role_policy".  Therefore, it doesn't
+  # matter which remote state we use here.
+  policy_arn = data.terraform_remote_state.sharedservices_networking_staging.outputs.assume_read_terraform_state_role_policy.arn
+}

--- a/assume_read_userservices_networking_state_role.tf
+++ b/assume_read_userservices_networking_state_role.tf
@@ -1,0 +1,14 @@
+# Attach to the provisioners users group the IAM policy (created in
+# cisagov/cool-userservices-networking) that allows assumption of the role
+# in the Terraform account that allows read-only access to the
+# cool-userservices-networking Terraform state.
+resource "aws_iam_group_policy_attachment" "assume_read_userservices_networking_state_role" {
+  provider = aws.users
+
+  group = aws_iam_group.provisioner_users.name
+  # There is only one Users account, so both userservices_networking
+  # remote states (production and staging) point to the same
+  # "assume_read_terraform_state_role_policy".  Therefore, it doesn't
+  # matter which remote state we use here.
+  policy_arn = data.terraform_remote_state.userservices_networking_staging.outputs.assume_read_terraform_state_role_policy.arn
+}

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -93,3 +93,18 @@ data "terraform_remote_state" "userservices_staging" {
 
   workspace = "staging"
 }
+
+data "terraform_remote_state" "userservices_networking_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-userservices-networking/terraform.tfstate"
+  }
+
+  workspace = "staging"
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR attaches two additional AWS policies to the Domain Manager provisioners group:
* Read-only access to the Terraform state for [`cisagov/cool-sharedservices-networking`](https://github.com/cisagov/cool-sharedservices-networking)
* Read-only access to the Terraform state for [`cisagov/cool-userservices-networking`](https://github.com/cisagov/cool-userservices-networking)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The Terraform states mentioned above contain information that is needed during the provisioning/deployment process of Domain Manager (e.g. [here](https://github.com/cisagov/domain-manager-cicd/blob/e0dfefbcc58e217de5d832255cf6e7c9f9dc4853/cool/route53.tf#L2) and [here](https://github.com/cisagov/domain-manager-cicd/blob/e0dfefbcc58e217de5d832255cf6e7c9f9dc4853/cool/networking.tf#L2-L4)).

This is part of the work required for https://github.com/cisagov/cool-system/issues/114.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change was successfully Terraformed and all pre-commit hooks pass.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
